### PR TITLE
chore: add dependabot automerge action

### DIFF
--- a/.github/workflows/covidgreen-tests-linting.yml
+++ b/.github/workflows/covidgreen-tests-linting.yml
@@ -40,3 +40,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run lint
+
+  automerge:
+    needs: [run-tests, verify-lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v1.2.1
+        if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change will cause dependabot PRs to be merged automatically when they pass the CI checks.